### PR TITLE
add support to prefetch container images on pools

### DIFF
--- a/examples/vizer/batch.jsonc
+++ b/examples/vizer/batch.jsonc
@@ -27,7 +27,14 @@
             /// The "storage-account-tag" is used to look up the storage account defined in `storage.jsonc`.
             "mounts": {
                 "datasets": "storage0/datasets"
-            }
+            },
+
+            /// container images to prefetch on the pool nodes.
+            /// to use images from ACR deployed as part of the deployment, use '${acr}' as prefix,
+            /// e.g. '${acr}/myrepository/myimage:tag'
+            "containerImages": [
+                "docker.io/utkarshayachit/vizer:osmesa-main"
+            ]
         }
     ]
 }

--- a/modules/containerImages.bicep
+++ b/modules/containerImages.bicep
@@ -1,0 +1,4 @@
+param images array = []
+param acrLoginServer string = ''
+
+output containerImageNames array = map(images, item => replace(item, '\${acr}', acrLoginServer))

--- a/schemas/batch.schema.json
+++ b/schemas/batch.schema.json
@@ -76,6 +76,16 @@
                         "additionalProperties": false
                     },
 
+                    "containerImages": {
+                        "description": "container images to prefetch on pool nodes",
+                        "type": "array",
+                        "default": [],
+                        "items": {
+                            "description": "container image to prefetch; use '${acr}' as login server for ACR deployed as part of the deployment",
+                            "type": "string"
+                        }
+                    },
+
                     "startTask": {
                         "description": "start task for pool",
                         "type": "object",


### PR DESCRIPTION
`batch.jsonc` now supports the following:

```jsonc
{
    ...
    /// adding a single linux pool
    "pools": [
        {
            /// Name for the pool. This is used to identify the pool in the batch account. It must be unique
            /// across all pools on this batch account.
            "name": "linux",

            ...

            /// container images to prefetch on the pool nodes.
            /// to use images from ACR deployed as part of the deployment, use '${acr}' as prefix,
            /// e.g. '${acr}/myrepository/myimage:tag'
            "containerImages": [
                "docker.io/utkarshayachit/vizer:osmesa-main"
            ]
        }
    ]
}

```
fixes #59.