### PR TITLE
fix blobfuse + SAS token

### DIFF
--- a/modules/mountConfigurations.bicep
+++ b/modules/mountConfigurations.bicep
@@ -25,7 +25,7 @@ var configsBFS = map(blobBFSConfigs, c => {
   azureBlobFileSystemConfiguration : union({
     accountName: c.name
     containerName: c.container
-    blobfuseOptions: '-o attr_timeout=240 -o entry_timeout=240 -o negative_timeout=120'
+    blobfuseOptions: '-o attr_timeout=240 -o entry_timeout=240 -o negative_timeout=120 -o allow_other'
     relativeMountPath: c.key
   }, !empty(c.credentials) ? c.credentials : {
     identityReference: {


### PR DESCRIPTION
When mounting with SAS token, blobfuse was not working as expected on compute nodes. Adding `-o allow_other` seems to have done the trick.